### PR TITLE
feat: use selected text as default filter tag for test filter command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,26 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## [0.1.0] - 2024-05-30
+## [0.2.0] - 2025-05-30
+
+### Added
+
+- Use selected text as default filter tag when running the "Test Filter" command.
+
+## [0.1.0] - 2025-05-30
 
 ### Added
 
 - Added configuration option to allow users to set the command used to run Artisan (e.g., php, ./vendor/bin/sail, docker-compose, etc).
 
-## [0.0.7] - 2024-11-13
+## [0.0.7] - 2025-11-13
 
 ### Removed
 
 - Removed configuration options for enabling/disabling hover link.
 - Removed hover link functionality for running test methods.
 
-## [0.0.6] - 2024-11-08
+## [0.0.6] - 2025-11-08
 
 ### Added
 
@@ -28,33 +34,33 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added CodeActions to run test methods.
 - Added configuration options to enable/disable CodeLens, hover, and CodeActions.
 
-## [0.0.5] - 2024-11-08
+## [0.0.5] - 2025-11-08
 
 ### Changed
 
 - Adjusted `runTestCreate` command to handle user cancellation.
 - Added example for creating test files using Laravel Artisan.
 
-## [0.0.4] - 2024-11-08
+## [0.0.4] - 2025-11-08
 
 ### Added
 
 - Add runTestCreate command to create test files with user input
 
-## [0.0.3] - 2024-11-08
+## [0.0.3] - 2025-11-08
 
 ### Changed
 
 - Adjusted conditions for `artisanTest.runTestFile` and `artisanTest.runTestDirty` commands to ensure correct execution based on file name.
 
-## [0.0.2] - 2024-11-08
+## [0.0.2] - 2025-11-08
 
 ### Added
 
 - Added icon for the extension.
 - Added GIFs demonstrating the functionality of the extension.
 
-## [0.0.1] - 2024-11-05
+## [0.0.1] - 2025-11-05
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "artisan-test-shortcut",
   "displayName": "Artisan Test Shortcut",
   "description": "Shortcuts for Artisan Test",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "icon": "images/icon.png",
   "publisher": "jjdevzinho",
   "author": "jjdevzinho <jjdevzinho@gmail.com>",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,16 @@ function runTask(taskName: string) {
           }
         });
     } else if (taskName === "Artisan Test Filter") {
-      vscode.window.showInputBox({ prompt: "Enter the filter tag for the test" }).then((filterTag) => {
+      // get the selected text from the active editor
+      const editor = vscode.window.activeTextEditor;
+      const selectedText = editor && !editor.selection.isEmpty
+        ? editor.document.getText(editor.selection)
+        : "";
+
+      vscode.window.showInputBox({
+        prompt: "Enter the filter tag for the test",
+        value: selectedText // default to selected text if available
+      }).then((filterTag) => {
         if (filterTag) {
           const vscodeTask = new vscode.Task(
             { type: task.type, task: task.label },
@@ -234,4 +243,4 @@ function runTestCreate() {
   });
 }
 
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
feat: use selected text as default filter tag for test filter command
This PR adds support for using the currently selected text in the editor as the default value for the filter tag when running the "Test Filter" command (Ctrl+F10).
If no text is selected, the input box will be empty as before.

This should make it easier and faster to run filtered tests based on any text selection.

Closes #1